### PR TITLE
Fix: import statement repeated twice

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import { League_Spartan } from 'next/font/google'
 import type { Metadata } from 'next'
-import { League_Spartan } from 'next/font/google'
 
 export const metadata: Metadata = {
   title: 'Invoice App',


### PR DESCRIPTION
### Description
- ### `src/pages/layout.tsx`
  ```tsx
  import { League_Spartan } from 'next/font/google'
  import type { Metadata } from 'next'
  import { League_Spartan } from 'next/font/google'
  ```
  - removed repeated import statement of `League_Spartan`
  

### Checklist
- [x] Code compiles correctly